### PR TITLE
Gather metrics within initializer

### DIFF
--- a/plugins/@grouparoo/prometheus/__tests__/action/metrics_test.ts
+++ b/plugins/@grouparoo/prometheus/__tests__/action/metrics_test.ts
@@ -43,7 +43,8 @@ describe("integration/endpoint/prometheus", () => {
         url,
       });
       expect(status).toEqual(200);
-      expect(data).toBeDefined(); //TODO: a better comparison
+      expect(data).toContain(`process_cpu_user_seconds_total`);
+      expect(data).toContain(`grouparoo_workers_cluster_count 1`);
     });
   });
 });

--- a/plugins/@grouparoo/prometheus/__tests__/initializers/plugin.ts
+++ b/plugins/@grouparoo/prometheus/__tests__/initializers/plugin.ts
@@ -1,0 +1,18 @@
+import path from "path";
+process.env.GROUPAROO_INJECTED_PLUGINS = JSON.stringify({
+  "@grouparoo/prometheus": { path: path.join(__dirname, "..", "..") },
+});
+
+import { helper } from "@grouparoo/spec-helper";
+import { api } from "actionhero";
+
+describe("initializer/prometheus", () => {
+  helper.grouparooTestServer({ truncate: true, enableTestPlugin: false });
+
+  test("the prometheus plugin is loaded and can get relevant metrics", async () => {
+    await api.prometheus.observe();
+    const response = await api.prometheus.registry.metrics();
+    expect(response).toContain(`process_cpu_user_seconds_total`);
+    expect(response).toContain(`grouparoo_workers_cluster_count`);
+  });
+});

--- a/plugins/@grouparoo/prometheus/src/actions/metrics.ts
+++ b/plugins/@grouparoo/prometheus/src/actions/metrics.ts
@@ -1,13 +1,10 @@
-import { Action } from "actionhero";
-import { AuthenticatedAction, Status } from "@grouparoo/core";
-import { collectDefaultMetrics, Gauge, Registry } from "prom-client";
+import { api } from "actionhero";
+import { AuthenticatedAction } from "@grouparoo/core";
 
-const register = new Registry();
-
-export default class PrometheusAction extends AuthenticatedAction {
+export default class PrometheusMetrics extends AuthenticatedAction {
   constructor() {
     super();
-    this.name = "prometheus:getMetrics";
+    this.name = "prometheus:metrics";
     this.description = "Metrics endpoint supporting prometheus format";
     this.permission = { topic: "system", mode: "read" };
   }
@@ -17,41 +14,7 @@ export default class PrometheusAction extends AuthenticatedAction {
       "Content-Type",
       "text/plain",
     ]);
-    data.response = await register.metrics();
+    await api.prometheus.observe();
+    data.response = await api.prometheus.registry.metrics();
   }
 }
-
-//TODO: target specific metrics *OR* generalize to any metric
-const workersCount = new Gauge({
-  name: "workers_count",
-  help: "Number of workers in the cluster",
-  async collect() {
-    let status = await Status.getCurrent();
-    this.set(status.workers.cluster[0].metric.count);
-  },
-});
-register.registerMetric(workersCount);
-
-//SEE: https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md
-//SEE: https://github.com/grouparoo/grouparoo/blob/c850e80cae15615ce8276bc7d5e66d72f600ce95/core/__tests__/modules/status.ts#L106
-
-//Destination.deleted[0].metric.count         Number
-//Export.pending[0].metric.count              Number
-//Group.deleted[0].metric.country             Number
-//Group.totals[0].metric.count                Number
-//Import.pending[0].metric.count              Number
-//Import.pendingBySource.metric.count         Number
-//Profile.pending[0].metric.count             Number
-//Profile.deleted[0].metric.count             Number
-//Profile.totals[0].metric.count              Number
-//Property.deleted[0].metric.count            Number
-//Run.pending[0].metric.count                 Number
-//Run.percentComplete[0].metric.count         ???
-//Source.deleted[0].metric.count              Number
-//Source.nextRun[0].metric.count              Number
-//node_env.cluster[0].metric.value            String e.g. "test"
-//os.cluster[0].metric.value                  String e.g. "linux"
-//resqueDetails.cluster[0].metric.value       ??? e.g. "structure"
-//resqueErrors.cluster[0].metric.count        Number
-//unreadNotifications.cluster[0].metric.count Number
-//workers.cluster[0].metric.count             Number

--- a/plugins/@grouparoo/prometheus/src/initializers/plugin.ts
+++ b/plugins/@grouparoo/prometheus/src/initializers/plugin.ts
@@ -1,21 +1,117 @@
-import { Initializer, route } from "actionhero";
+import { Initializer, route, api } from "actionhero";
+import { Status } from "@grouparoo/core";
+import { collectDefaultMetrics, Gauge, Registry } from "prom-client";
+
+declare module "actionhero" {
+  export interface Api {
+    prometheus: {
+      registry: Registry;
+      observe: () => Promise<void>;
+      gauges: Array<Gauge<any>>;
+    };
+  }
+}
+
 const packageJSON = require("./../../package.json");
 
 export default class PrometheusInitializer extends Initializer {
   constructor() {
     super();
     this.name = packageJSON.name;
+    this.startPriority = 100;
   }
 
   async initialize() {
     route.registerRoute(
       "get",
       "/v:apiVersion/prometheus/metrics",
-      "prometheus:getMetrics"
+      "prometheus:metrics"
     );
   }
 
-  async start() {}
+  async start() {
+    api.prometheus = {
+      gauges: [],
+      registry: new Registry(),
+      observe: this.observe,
+    };
+    collectDefaultMetrics({ register: api.prometheus.registry });
 
-  async stop() {}
+    // the name of he metric matches `grouparoo_collectionName_typeName_aggregationName`
+
+    api.prometheus.gauges.push(
+      new Gauge({
+        name: "grouparoo_workers_cluster_count",
+        help: "Number of workers in the cluster",
+      })
+    );
+
+    api.prometheus.gauges.push(
+      new Gauge({
+        name: "grouparoo_resqueErrors_cluster_count",
+        help: "Number of Resque Errors in the cluster",
+      })
+    );
+
+    api.prometheus.gauges.push(
+      new Gauge({
+        name: "grouparoo_Run_pending_count",
+        help: "Number of pending Runs in the cluster",
+      })
+    );
+
+    api.prometheus.gauges.push(
+      new Gauge({
+        name: "grouparoo_Import_pending_count",
+        help: "Number of pending Import in the cluster",
+      })
+    );
+
+    api.prometheus.gauges.push(
+      new Gauge({
+        name: "grouparoo_Profile_pending_count",
+        help: "Number of pending Profiles in the cluster",
+      })
+    );
+
+    api.prometheus.gauges.push(
+      new Gauge({
+        name: "grouparoo_Export_pending_count",
+        help: "Number of pending Exports in the cluster",
+      })
+    );
+
+    api.prometheus.gauges.push(
+      new Gauge({
+        name: "grouparoo_Profile_totals_count",
+        help: "Number of Profiles in the cluster",
+      })
+    );
+
+    api.prometheus.gauges.forEach((g) =>
+      api.prometheus.registry.registerMetric(g)
+    );
+  }
+
+  // take the most recent status metrics from Grouparoo and load them into the Prometheus histograms we want
+  async observe() {
+    const status = await Status.getCurrent();
+
+    for (const gauge of api.prometheus.gauges) {
+      const [owner, collectionName, typeName, aggregationName] = gauge[
+        "name"
+      ].split("_") as string[];
+
+      if (owner !== "grouparoo") continue;
+      const collection = status[collectionName];
+      if (!collection) continue;
+      const metrics = collection[typeName];
+      if (!metrics) continue;
+      if (metrics.length === 0) continue;
+
+      const metric = metrics[0];
+      const value = metric.metric[aggregationName];
+      if (value !== undefined) gauge.set(value);
+    }
+  }
 }


### PR DESCRIPTION
* Move most logic to the Initializer
* Simplify Action
* Test
* Gather some metrics about pending things in the system



Data returned looks like:

```
# HELP grouparoo_workers_cluster_count Number of workers in the cluster
# TYPE grouparoo_workers_cluster_count gauge
grouparoo_workers_cluster_count 5

# HELP grouparoo_resqueErrors_cluster_count Number of Resque Errors in the cluster
# TYPE grouparoo_resqueErrors_cluster_count gauge
grouparoo_resqueErrors_cluster_count 0

# HELP grouparoo_Run_pending_count Number of pending Runs in the cluster
# TYPE grouparoo_Run_pending_count gauge
grouparoo_Run_pending_count 1

# HELP grouparoo_Import_pending_count Number of pending Import in the cluster
# TYPE grouparoo_Import_pending_count gauge
grouparoo_Import_pending_count 1000

# HELP grouparoo_Profile_pending_count Number of pending Profiles in the cluster
# TYPE grouparoo_Profile_pending_count gauge
grouparoo_Profile_pending_count 73

# HELP grouparoo_Export_pending_count Number of pending Exports in the cluster
# TYPE grouparoo_Export_pending_count gauge
grouparoo_Export_pending_count 0

# HELP grouparoo_Profile_totals_count Number of Profiles in the cluster
# TYPE grouparoo_Profile_totals_count gauge
grouparoo_Profile_totals_count 73
```

Of note - I named the metrics using an `_` scheme that matches the Status keys so that we only had to call `Status.getCurrent();` once and we could look up each metric from there.